### PR TITLE
clean up the usage and allow "-h" to work

### DIFF
--- a/software/util/imx53_bootrom-dump.c
+++ b/software/util/imx53_bootrom-dump.c
@@ -60,11 +60,13 @@ int main(int argc, char **argv) {
 	unsigned long read_result, writeval;
 	off_t target;
 
-	if (argc < 1) {
-		fprintf(stderr, "\nUsage:\t%s { address } [ data ]\n"
-			"\taddress : memory address to act upon\n"
-			"\tdata	: data to be written\n\n",
+	if ((argc < 1) || (strcmp(argv[1], "-h") == 0)) {
+		fprintf(stderr, "\nUsage:\t%s <address> <len>\n"
+			"\taddress : memory address to read\n"
+			"\tlen	: number of KB to be read\n\n",
 			argv[0]);
+		fprintf(stderr, "\t%s 0 16 > bootrom-0-16k.bin\n", argv[0]);
+		fprintf(stderr, "\t%s 0x404000 48 > bootrom-1-48k.bin\n", argv[0]);
 		exit(1);
 	}
 	target = strtoul(argv[1], 0, 0);


### PR DESCRIPTION
    usbarmory$ ./imx53_bootrom-dump -h
    Segmentation fault

Right then, let's fix that. With this diff, a useful help message is produced.

    usbarmory$ ./imx53_bootrom-dump -h
    Usage:	./imx53_bootrom-dump <address> <len>
        address : memory address to read
        len	: number of KB to be read
    
        ./imx53_bootrom-dump 0 16 > bootrom-0-16k.bin
        ./imx53_bootrom-dump 0x404000 48 > bootrom-1-48k.bin
