### PR TITLE
bumped latest mxc-scc2 changeset

### DIFF
--- a/software/buildroot/package/mxc-scc2/mxc-scc2.mk
+++ b/software/buildroot/package/mxc-scc2/mxc-scc2.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MXC_SCC2_VERSION = 258a0a55294d9c63347061fb238c2d99036a05cf
+MXC_SCC2_VERSION = 86715939212dc83a54661f01a701ee7738588ba0
 MXC_SCC2_SITE = $(call github,inversepath,mxc-scc2,$(MXC_SCC2_VERSION))
 MXC_SCC2_REPO = https://github.com/inversepath/mxc-scc2
 


### PR DESCRIPTION
Buildroot (2019.02.4) `interlock_mark-one_defconfig` fails with following error: 
```
...
>>> mxc-scc2 258a0a55294d9c63347061fb238c2d99036a05cf Configuring
>>> mxc-scc2 258a0a55294d9c63347061fb238c2d99036a05cf Building
/usr/bin/make -j5 HOSTCC="/usr/bin/gcc -O2 -I/home/a/src/buildroot/output/host/include -L/home/a/src/buildroot/output/host/lib -Wl,-rpath,/home/a/src/buildroot/output/host/lib" ARCH=arm INSTALL_MOD_PATH=/home/a/src/buildroot/output/target CROSS_COMPILE="/home/a/src/buildroot/output/host/bin/arm-buildroot-linux-gnueabihf-" DEPMOD=/home/a/src/buildroot/output/host/sbin/depmod INSTALL_MOD_STRIP=1 -C /home/a/src/buildroot/output/build/linux-4.19.65 M=/home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf modules
make[1]: Entering directory '/home/a/src/buildroot/output/build/linux-4.19.65'
  CC [M]  /home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/scc2_driver.o
/home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/scc2_driver.c:2475:28: error: array type has incomplete element type ‘struct of_device_id’
 static struct of_device_id scc_dt_ids[] = {
                            ^~~~~~~~~~
/home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/scc2_driver.c:2476:4: error: field name not in record or union initializer
  { .compatible = "fsl,imx53-scc2" },
    ^
/home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/scc2_driver.c:2476:4: note: (near initialization for ‘scc_dt_ids’)
make[2]: *** [scripts/Makefile.build:304: /home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/scc2_driver.o] Error 1
make[1]: *** [Makefile:1519: _module_/home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf] Error 2
make[1]: Leaving directory '/home/a/src/buildroot/output/build/linux-4.19.65'
make: *** [package/pkg-generic.mk:241: /home/a/src/buildroot/output/build/mxc-scc2-258a0a55294d9c63347061fb238c2d99036a05cf/.stamp_built] Error 2
```

Bumping latest mxc-scc2 appears to work flawlessly. 